### PR TITLE
[56774-33] Change SalesChannelContextService to SalesChannelContextServiceInterface on HelloRetailExportHandler (6.6)

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 5.3.11
+* SalesChannelContextService anstelle von SalesChannelContextServiceInterface geändert.
+
 # 5.3.10
 * Plugin-Basisklasse (HelretHelloRetail.php) wiederhergestellt, die in 5.3.9 versehentlich entfernt wurde und die Installation sowie Updates des Plugins verhinderte
 

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,6 @@
+# 5.3.11
+* Changed SalesChannelContextServiceInterface instead of SalesChannelContextService on Product Export
+
 # 5.3.10
 * Restored the plugin base class (HelretHelloRetail.php) that was accidentally removed in 5.3.9, which prevented the plugin from being installed and updated
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Hello Retail integration for Shopware 6",
     "type": "shopware-platform-plugin",
     "license": "proprietary",
-    "version": "5.3.10",
+    "version": "5.3.11",
     "authors": [
         {
             "name": "WEXO A/S",

--- a/src/Component/MessageQueue/HelloRetailExportHandler.php
+++ b/src/Component/MessageQueue/HelloRetailExportHandler.php
@@ -22,7 +22,7 @@ use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Shopware\Core\Framework\Struct\ArrayStruct;
@@ -51,7 +51,7 @@ class HelloRetailExportHandler
         protected HelloRetailService $helloRetailService,
         protected MessageBusInterface $bus,
         protected ProductStreamBuilderInterface $productStreamBuilder,
-        protected SalesChannelContextService $salesChannelContextService
+        protected SalesChannelContextServiceInterface $salesChannelContextService
     ) {
         $fullPath = $helloRetailService->getFeedDirectoryPath();
         $this->filesystem = new Filesystem(new LocalFilesystemAdapter($fullPath));


### PR DESCRIPTION
## Summary
- Ports the master/6.7 fix from PR #45 to the `6.6` branch, as requested in #44 (comment).
- `HelloRetailExportHandler` type-hinted the concrete `SalesChannelContextService` instead of `SalesChannelContextServiceInterface`. When another plugin (e.g. Buckaroo) decorates that service, the handler crashes with a `TypeError` and the product feed export fails on every message.
- Same change as the master fix: use the interface instead of the concrete class.

Fixes #44

## Test plan
- [ ] `php -l` on the changed file (done locally, no syntax errors)
- [ ] Verify `SalesChannelContextServiceInterface` exists in `shopware/core` ~6.6 (confirmed against the shopware/platform v6.6.x tags)
- [ ] Install on a Shopware 6.6 instance with a plugin that decorates `SalesChannelContextService` (e.g. Buckaroo) and confirm the product feed export no longer throws